### PR TITLE
Update gradle-wrapper.properties

### DIFF
--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,11 @@
-#Fri Jun 23 08:50:38 CEST 2017
+# Fri Jun 23 08:50:38 CEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-7.6.2-all.zip
+
+# UPDATE BY A STUDENT
+# Up-to-date Gradle version was 7.0.2 in 2017 but it needs to be updated in 7.07.2023, otherwise it won't run with your up-to-date java version.
+# I tried 8.2 Gradle but it didn't work however 7.6.2 Gradle works fine and also supports Java 17.
+# Check for your versions: https://docs.gradle.org/current/userguide/compatibility.html


### PR DESCRIPTION
Hello, I'm a student from The Complete Flutter Development Bootcamp with Dart. I was having a problem with the versions and just wanted to contribute to making other's life easier.

The gradle version of this project was outdated, hence it wasn't supporting the up-to-date version of Java (which I tried Java 17).

I tried with Gradle 8.2 but it wasn't working however 7.6.2 is good enough at 7.07.2023.

The original Gradle version was 7.0.2.
I updated it as 7.6.2.